### PR TITLE
Fix the missing `examples` dir bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,12 @@ pub fn build(b: *std.Build) void {
     // 1. Get the dependency object from the builder
     const chilli_dep = b.dependency("chilli", .{});
 
-    // 2. Create a module for the dependency
-    const chilli_module = chilli_dep.module("chilli");
+    // 2. Create a module for the dependency directly from its source file
+    const chilli_module = b.createModule(.{
+        .root_source_file = chilli_dep.path("src/lib.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
 
     // 3. Create your executable module and add chilli as import
     const exe_module = b.createModule(.{

--- a/README.md
+++ b/README.md
@@ -65,12 +65,8 @@ pub fn build(b: *std.Build) void {
     // 1. Get the dependency object from the builder
     const chilli_dep = b.dependency("chilli", .{});
 
-    // 2. Create a module for the dependency directly from its source file
-    const chilli_module = b.createModule(.{
-        .root_source_file = chilli_dep.path("src/lib.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
+    // 2. Create a module for the dependency
+    const chilli_module = chilli_dep.module("chilli");
 
     // 3. Create your executable module and add chilli as import
     const exe_module = b.createModule(.{

--- a/build.zig
+++ b/build.zig
@@ -62,33 +62,40 @@ pub fn build(b: *std.Build) void {
 
     // --- Example Setup ---
     const examples_path = "examples";
-    var examples_dir = fs.cwd().openDir(examples_path, .{ .iterate = true }) catch @panic("Can't open 'examples' directory");
-    defer examples_dir.close();
+    examples_blk: {
+        // If the examples directory isn't present (common when used as a dependency),
+        // skip setting up example artifacts instead of panicking.
+        var examples_dir = fs.cwd().openDir(examples_path, .{ .iterate = true }) catch |err| {
+            if (err == error.FileNotFound or err == error.NotDir) break :examples_blk;
+            @panic("Can't open 'examples' directory");
+        };
+        defer examples_dir.close();
 
-    var dir_iter = examples_dir.iterate();
-    while (dir_iter.next() catch @panic("Failed to iterate examples")) |entry| {
-        if (!std.mem.endsWith(u8, entry.name, ".zig")) continue;
+        var dir_iter = examples_dir.iterate();
+        while (dir_iter.next() catch @panic("Failed to iterate examples")) |entry| {
+            if (!std.mem.endsWith(u8, entry.name, ".zig")) continue;
 
-        const exe_name = fs.path.stem(entry.name);
-        const exe_path = b.fmt("{s}/{s}", .{ examples_path, entry.name });
+            const exe_name = fs.path.stem(entry.name);
+            const exe_path = b.fmt("{s}/{s}", .{ examples_path, entry.name });
 
-        const exe_module = b.createModule(.{
-            .root_source_file = b.path(exe_path),
-            .target = target,
-            .optimize = optimize,
-        });
-        exe_module.addImport("chilli", lib_module);
+            const exe_module = b.createModule(.{
+                .root_source_file = b.path(exe_path),
+                .target = target,
+                .optimize = optimize,
+            });
+            exe_module.addImport("chilli", lib_module);
 
-        const exe = b.addExecutable(.{
-            .name = exe_name,
-            .root_module = exe_module,
-        });
-        b.installArtifact(exe);
+            const exe = b.addExecutable(.{
+                .name = exe_name,
+                .root_module = exe_module,
+            });
+            b.installArtifact(exe);
 
-        const run_cmd = b.addRunArtifact(exe);
-        const run_step_name = b.fmt("run-{s}", .{exe_name});
-        const run_step_desc = b.fmt("Run the {s} example", .{exe_name});
-        const run_step = b.step(run_step_name, run_step_desc);
-        run_step.dependOn(&run_cmd.step);
+            const run_cmd = b.addRunArtifact(exe);
+            const run_step_name = b.fmt("run-{s}", .{exe_name});
+            const run_step_desc = b.fmt("Run the {s} example", .{exe_name});
+            const run_step = b.step(run_step_name, run_step_desc);
+            run_step.dependOn(&run_cmd.step);
+        }
     }
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .chilli,
-    .version = "0.2.0",
+    .version = "0.2.1",
     .fingerprint = 0x6c259741ae4f5f73, // Changing this has security and trust implications.
     .minimum_zig_version = "0.15.1",
     .paths = .{

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,6 @@
 name = "chilli"
 version = "0.1.0"
 description = "Python environment for Chilli"
-readme = "README.md"
-license = { text = "MIT" }
-authors = [
-    { name = "Hassan Abedi", email = "hassan.abedi.t@gmail.com" }
-]
 
 requires-python = ">=3.10,<4.0"
 dependencies = [


### PR DESCRIPTION
* Fix the missing `examples` directory bug, which caused panic when an application used Chilli and didn't have an examples directory located in its root directory.